### PR TITLE
Update ntripserver-init.sh

### DIFF
--- a/ntripserver-init.sh
+++ b/ntripserver-init.sh
@@ -15,7 +15,18 @@ pidfile="/var/run/ntripserver.pid"
 daemon_opts=""
     
 [ -x "${daemon}" ] || exit 0
-    
+
+if [ -f $pidfile ]; then
+   pid=$(<$pidfile)
+   echo $pid
+   if [ -d "/proc/$pid" ]; then
+       echo "Process running"
+   else
+       rm -f $pidfile
+       echo "Process not running, remove pidfile"
+   fi
+fi
+
 case "${1}" in
     start)
         echo -n "Starting ntripserver: "


### PR DESCRIPTION
To prevent against situation when pidfile is present, but process is killed.